### PR TITLE
Ensure plain_text field always returned 

### DIFF
--- a/readability.py
+++ b/readability.py
@@ -31,7 +31,8 @@ def parse(html, content_digests=False):
         "title": None,
         "byline": None,
         "content": None,
-        "plain_content": None
+        "plain_content": None,
+        "plain_text": None
     }
     # Populate article fields from readability fields where present
     if readability_json:


### PR DESCRIPTION
Ensure plain_text field always returned (with null value if no article exported). Missed in PR #15 